### PR TITLE
⚡️ reduce memory allocs, concurrent safe

### DIFF
--- a/validator/thai_id_validator.go
+++ b/validator/thai_id_validator.go
@@ -16,7 +16,7 @@ var thaiIDRegexPool = sync.Pool{
 }
 
 func ThaiIDValidator(id string) bool {
-	if len(id) == 0 {
+	if len(id) != 13 {
 		return false
 	}
 

--- a/validator/thai_id_validator.go
+++ b/validator/thai_id_validator.go
@@ -3,26 +3,37 @@ package validator
 import (
 	"regexp"
 	"strconv"
+	"sync"
 )
 
+var thaiIDRegexPool = sync.Pool{
+	New: func() interface{} {
+		// The Pool's New function should generally only return pointer
+		// types, since a pointer can be put into the return interface
+		// value without an allocation:
+		return regexp.MustCompile("!/^[0-9]{13}$/g")
+	},
+}
+
 func ThaiIDValidator(id string) bool {
-	if id == "" {
+	if len(id) == 0 {
 		return false
 	}
 
-	r, _ := regexp.Compile("!/^[0-9]{13}$/g")
-	if r.MatchString(id) {
+	thaiIDRegex := thaiIDRegexPool.Get().(*regexp.Regexp)
+	defer thaiIDRegexPool.Put(thaiIDRegex)
+	if thaiIDRegex.MatchString(id) {
 		return false
 	}
 
 	sum := 0
-	for i, n := range id[0 : len(id)-1] {
-		xint, _ := strconv.Atoi(string(n))
+	for i := 0; i < len(id)-1; i++ {
+		xint, _ := strconv.Atoi(string(id[i]))
 		sum += xint * (13 - i)
 	}
 
 	checkSum := (11 - sum%11) % 10
-	last_num, _ := strconv.Atoi(id[len(id)-1:])
+	lastNum, _ := strconv.Atoi(string(id[len(id)-1]))
 
-	return checkSum == last_num
+	return checkSum == lastNum
 }

--- a/validator/thai_id_validator_test.go
+++ b/validator/thai_id_validator_test.go
@@ -27,3 +27,13 @@ func TestEmpty_ThaiIDValidator(t *testing.T) {
 		t.Fatalf(`ThaiIDValidator("") got %v, want %v`, actual, expected)
 	}
 }
+
+func BenchmarkThaiIDValidator(b *testing.B) {
+	b.ReportAllocs()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ThaiIDValidator("1112034563562")
+		}
+	})
+}


### PR DESCRIPTION
- Thai ID length must be 13
- use sync pool to reuse regex resources and safe for large concurrent request
- improve performance around 100x by eliminated unnecessary memory allocate
before:
`BenchmarkThaiIDValidator-16    	  402103	      3051 ns/op	    4488 B/op	      35 allocs/op`
after:
`BenchmarkThaiIDValidator-16    	62505306	        18.55 ns/op	       0 B/op	       0 allocs/op`